### PR TITLE
Further json cleanup

### DIFF
--- a/src/Syringe.Core/Syringe.Core.csproj
+++ b/src/Syringe.Core/Syringe.Core.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Helpers\UrlHelper.cs" />
     <Compile Include="Logging\SimpleLogger.cs" />
     <Compile Include="Tests\Repositories\Json\Reader\TestFileReader.cs" />
+    <Compile Include="Tests\Repositories\Json\Writer\SerializationContract.cs" />
     <Compile Include="Tests\Repositories\Json\Writer\TestFileWriter.cs" />
     <Compile Include="Tests\Results\Repositories\ITestFileResultRepository.cs" />
     <Compile Include="Tests\Results\Repositories\TestFileResultRepository.cs" />

--- a/src/Syringe.Core/Tests/Repositories/Json/Writer/SerializationContract.cs
+++ b/src/Syringe.Core/Tests/Repositories/Json/Writer/SerializationContract.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Syringe.Core.Tests.Repositories.Json.Writer
+{
+    public class SerializationContract : DefaultContractResolver
+    {
+        private readonly string[] _propertiesToIgnore = 
+        {
+            "Filename"
+        };
+
+        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+        {
+            List<JsonProperty> defaultList = base.CreateProperties(type, memberSerialization).ToList();
+
+            List<JsonProperty> filtered = defaultList
+                            .Where(x => !_propertiesToIgnore.Any(p => p.Equals(x.PropertyName, StringComparison.InvariantCultureIgnoreCase)))
+                            .ToList();
+
+            return filtered;
+        }
+
+        public static JsonSerializerSettings GetSettings()
+        {
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = new SerializationContract()
+            };
+
+            return settings;
+        }
+    }
+}

--- a/src/Syringe.Core/Tests/Repositories/Json/Writer/SerializationContract.cs
+++ b/src/Syringe.Core/Tests/Repositories/Json/Writer/SerializationContract.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -8,9 +9,21 @@ namespace Syringe.Core.Tests.Repositories.Json.Writer
 {
     public class SerializationContract : DefaultContractResolver
     {
-        private readonly string[] _propertiesToIgnore = 
+        private readonly string[] _propertiesToIgnore =
         {
-            "Filename"
+            "Filename",
+            "TransformedValue"
+        };
+
+        private readonly PropertyInfo[] _propsToIgnore =
+        {
+            typeof (Test).GetProperty("Filename"),
+            typeof (Test).GetProperty("Position"),
+            typeof (Test).GetProperty("AvailableVariables"),
+            typeof (TestFile).GetProperty("Filename"),
+            typeof (TestFile).GetProperty("Environment"),
+            typeof (Variable).GetProperty("Order"),
+            typeof (Variable).GetProperty("Roles"),
         };
 
         protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
@@ -18,10 +31,24 @@ namespace Syringe.Core.Tests.Repositories.Json.Writer
             List<JsonProperty> defaultList = base.CreateProperties(type, memberSerialization).ToList();
 
             List<JsonProperty> filtered = defaultList
-                            .Where(x => !_propertiesToIgnore.Any(p => p.Equals(x.PropertyName, StringComparison.InvariantCultureIgnoreCase)))
-                            .ToList();
+                                .Where(x => !_propsToIgnore.Any(p => GetFullName(p) == GetFullName(x)))
+                                .ToList();
+
+            //List<JsonProperty> filtered = defaultList
+            //                .Where(x => !_propertiesToIgnore.Any(p => p.Equals(x.PropertyName, StringComparison.InvariantCultureIgnoreCase)))
+            //                .ToList();
 
             return filtered;
+        }
+
+        private string GetFullName(PropertyInfo propertyInfo)
+        {
+            return $"{propertyInfo?.DeclaringType?.FullName}.{propertyInfo?.Name}";
+        }
+
+        private string GetFullName(JsonProperty jsonProperty)
+        {
+            return $"{jsonProperty?.DeclaringType?.FullName}.{jsonProperty?.PropertyName}";
         }
 
         public static JsonSerializerSettings GetSettings()

--- a/src/Syringe.Core/Tests/Repositories/Json/Writer/TestFileWriter.cs
+++ b/src/Syringe.Core/Tests/Repositories/Json/Writer/TestFileWriter.cs
@@ -6,7 +6,7 @@ namespace Syringe.Core.Tests.Repositories.Json.Writer
     {
         public string Write(TestFile testFile)
         {
-            return JsonConvert.SerializeObject(testFile, Formatting.Indented);
+            return JsonConvert.SerializeObject(testFile, Formatting.Indented, SerializationContract.GetSettings());
         }
     }
 }

--- a/src/Syringe.Service/DependencyResolution/DefaultRegistry.cs
+++ b/src/Syringe.Service/DependencyResolution/DefaultRegistry.cs
@@ -103,7 +103,6 @@ namespace Syringe.Service.DependencyResolution
                 case TestFileFormat.Json:
                     For<ITestFileReader>().Use<Core.Tests.Repositories.Json.Reader.TestFileReader>();
                     For<ITestFileWriter>().Use<Core.Tests.Repositories.Json.Writer.TestFileWriter>();
-                    //For<ITestRepository>().Use<Core.Tests.Repositories.Json.TestRepository>();
                     break;
                 default:
                     throw new NotImplementedException("Unknown test file format");


### PR DESCRIPTION
We are no longer storing down info that we don't need via managed code.

I have purposely not added the JsonAttributes as this would probably break serialisation between the services and client.

@hemdagem @yetanotherchris 