### PR TITLE
Fixed build due to missing key

### DIFF
--- a/src/Syringe.Core/Runner/TestFileRunner.cs
+++ b/src/Syringe.Core/Runner/TestFileRunner.cs
@@ -10,6 +10,7 @@ using Syringe.Core.Runner.Assertions;
 using Syringe.Core.Tests;
 using Syringe.Core.Tests.Results;
 using Syringe.Core.Tests.Results.Repositories;
+using Syringe.Core.Tests.Scripting;
 using HttpResponse = Syringe.Core.Http.HttpResponse;
 
 namespace Syringe.Core.Runner
@@ -219,6 +220,32 @@ namespace Syringe.Core.Runner
                 var httpLogWriter = new HttpLogWriter();
 
 	            IRestRequest request = _httpClient.CreateRestRequest(test.Method, resolvedUrl, test.PostBody, test.Headers);
+				var logger = new SimpleLogger();
+
+				// Scripting part
+				if (!string.IsNullOrEmpty(test.BeforeExecuteScript))
+	            {
+					logger.WriteLine("--------------------------");
+		            logger.WriteLine("Evaluating C# script:");
+
+					try
+					{
+						var evaluator = new TestFileScriptEvaluator();
+						evaluator.EvaluateBeforeExecute(test.BeforeExecuteScript, test, request);
+
+						request = evaluator.RequestGlobals.Request;
+						test = evaluator.RequestGlobals.Test;
+						logger.WriteLine("Compilation OK");
+
+					}
+		            catch (Exception ex)
+		            {
+			            logger.WriteLine("Compilation failed: {0}", ex);
+		            }
+
+					logger.WriteLine("--------------------------");
+				}
+
 				HttpResponse response = await _httpClient.ExecuteRequestAsync(request, httpLogWriter);
                 testResult.ResponseTime = response.ResponseTime;
                 testResult.HttpResponse = response;
@@ -231,7 +258,7 @@ namespace Syringe.Core.Runner
                     string content = response.ToString();
 
                     // Put the parseresponse regex values in the current variable set
-                    var logger = new SimpleLogger();
+                    
 					logger.WriteLine("--------------------------");
 					logger.WriteLine("Parsing variables");
                     logger.WriteLine("--------------------------");

--- a/src/Syringe.Core/Tests/Repositories/TestRepository.cs
+++ b/src/Syringe.Core/Tests/Repositories/TestRepository.cs
@@ -80,18 +80,19 @@ namespace Syringe.Core.Tests.Repositories
 			{
 				collection = _testFileReader.Read(stringReader);
 
-				Test item = collection.Tests.ElementAt(test.Position);
+				Test singleTest = collection.Tests.ElementAt(test.Position);
 
-				item.Description = test.Description;
-			    item.Headers = test.Headers.Select(x => new HeaderItem(x.Key, x.Value)).ToList();
-				item.Method = test.Method;
-				item.Filename = test.Filename;
-				item.CapturedVariables = test.CapturedVariables;
-				item.PostBody = test.PostBody;
-				item.Assertions = test.Assertions;
-				item.Description = test.Description;
-				item.Url = test.Url;
-				item.ExpectedHttpStatusCode = test.ExpectedHttpStatusCode;
+				singleTest.Description = test.Description;
+			    singleTest.Headers = test.Headers.Select(x => new HeaderItem(x.Key, x.Value)).ToList();
+				singleTest.Method = test.Method;
+				singleTest.Filename = test.Filename;
+				singleTest.CapturedVariables = test.CapturedVariables;
+				singleTest.PostBody = test.PostBody;
+				singleTest.Assertions = test.Assertions;
+				singleTest.Description = test.Description;
+				singleTest.Url = test.Url;
+				singleTest.ExpectedHttpStatusCode = test.ExpectedHttpStatusCode;
+				singleTest.BeforeExecuteScript = test.BeforeExecuteScript;
 			}
 
 			string contents = _testFileWriter.Write(collection);

--- a/src/Syringe.Core/Tests/Results/TestResult.cs
+++ b/src/Syringe.Core/Tests/Results/TestResult.cs
@@ -25,7 +25,7 @@ namespace Syringe.Core.Tests.Results
 
 		public bool Success
 		{
-			get { return ResponseCodeSuccess && AssertionsSuccess; }
+			get { return ResponseCodeSuccess && AssertionsSuccess && ScriptCompilationSuccess; }
 		}
 		
 		public bool AssertionsSuccess
@@ -38,9 +38,13 @@ namespace Syringe.Core.Tests.Results
 				return AssertionResults.Count(x => x.Success == false) == 0;
 			}
 		}
+
+	    public bool ScriptCompilationSuccess { get; set; }
+
 		public TestResult()
 		{
             AssertionResults = new List<Assertion>();
+			ScriptCompilationSuccess = true;
 		}
 	}
 }

--- a/src/Syringe.Core/Tests/Scripting/RequestGlobals.cs
+++ b/src/Syringe.Core/Tests/Scripting/RequestGlobals.cs
@@ -1,4 +1,5 @@
 using RestSharp;
+using Syringe.Core.Configuration;
 
 namespace Syringe.Core.Tests.Scripting
 {
@@ -6,5 +7,6 @@ namespace Syringe.Core.Tests.Scripting
 	{
 		public Test Test { get; set; }
 		public IRestRequest Request { get; set; }
+		public IConfiguration Configuration { get; set; }
 	}
 }

--- a/src/Syringe.Core/Tests/Scripting/TestFileScriptEvaluator.cs
+++ b/src/Syringe.Core/Tests/Scripting/TestFileScriptEvaluator.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
 using RestSharp;
+using Syringe.Core.Configuration;
 using Syringe.Core.Exceptions;
 
 namespace Syringe.Core.Tests.Scripting
@@ -11,12 +12,13 @@ namespace Syringe.Core.Tests.Scripting
 	{
 		public RequestGlobals RequestGlobals { get; set; }
 
-		public TestFileScriptEvaluator()
+		public TestFileScriptEvaluator(IConfiguration configuration)
 		{
 			RequestGlobals = new RequestGlobals();
+			RequestGlobals.Configuration = configuration;
 		}
 
-		public void EvaluateBeforeExecute(string code, Test test, IRestRequest request)
+		public void EvaluateBeforeExecute(Test test, IRestRequest request)
 		{
 			RequestGlobals.Test = test;
 			RequestGlobals.Request = request;
@@ -27,7 +29,7 @@ namespace Syringe.Core.Tests.Scripting
 
 			try
 			{
-				CSharpScript.EvaluateAsync(code, options: scriptOptions, globals: RequestGlobals).Wait();
+				CSharpScript.EvaluateAsync(test.BeforeExecuteScript, options: scriptOptions, globals: RequestGlobals).Wait();
 			}
 			catch (CompilationErrorException ex)
 			{

--- a/src/Syringe.Service/Parallel/ParallelTestFileQueue.cs
+++ b/src/Syringe.Service/Parallel/ParallelTestFileQueue.cs
@@ -84,7 +84,7 @@ namespace Syringe.Service.Parallel
 
 					var httpClient = new HttpClient(new RestClient());
 
-					var runner = new TestFileRunner(httpClient, _repository);
+					var runner = new TestFileRunner(httpClient, _repository, _configuration);
 					Task<TestFileResult> task = runner.RunAsync(testFile);
 					bool success = task.Wait(TimeSpan.FromMinutes(3));
 
@@ -138,7 +138,7 @@ namespace Syringe.Service.Parallel
 
 					var httpClient = new HttpClient(new RestClient());
 
-					var runner = new TestFileRunner(httpClient, _repository);
+					var runner = new TestFileRunner(httpClient, _repository, _configuration);
 					item.Runner = runner;
 					await runner.RunAsync(testFile);
 				}

--- a/src/Syringe.Tests/Integration/Xml/TestFileRunnerTests.cs
+++ b/src/Syringe.Tests/Integration/Xml/TestFileRunnerTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
 using RestSharp;
+using Syringe.Core.Configuration;
 using Syringe.Core.Http;
 using Syringe.Core.Runner;
 using Syringe.Core.Tests;
@@ -26,13 +27,13 @@ namespace Syringe.Tests.Integration.Xml
 	    [Test]
 	    public void should_throw_ArgumentNullException_when_httpclient_is_null()
 	    {
-	        Assert.Throws<ArgumentNullException>(() => new TestFileRunner(null, new TestFileResultRepositoryMock()));
+	        Assert.Throws<ArgumentNullException>(() => new TestFileRunner(null, new TestFileResultRepositoryMock(), new JsonConfiguration()));
 	    }
 
         [Test]
         public void should_throw_ArgumentNullException_when_repository_is_null()
         {
-            Assert.Throws<ArgumentNullException>(() => new TestFileRunner(It.IsAny<IHttpClient>(), null));
+            Assert.Throws<ArgumentNullException>(() => new TestFileRunner(It.IsAny<IHttpClient>(), null, new JsonConfiguration()));
         }
 
         [Test]
@@ -45,7 +46,7 @@ namespace Syringe.Tests.Integration.Xml
 			var stringReader = new StringReader(xml);
 			var reader = new TestFileReader();
 			TestFile testFile = reader.Read(stringReader);
-			var runner = new TestFileRunner(httpClient, GetRepository());
+			var runner = new TestFileRunner(httpClient, GetRepository(), new JsonConfiguration());
 
 			// Act
 			TestFileResult result = await runner.RunAsync(testFile);

--- a/src/Syringe.Tests/Unit/Core/Runner/TestSessionRunnerTests.cs
+++ b/src/Syringe.Tests/Unit/Core/Runner/TestSessionRunnerTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
 using RestSharp;
+using Syringe.Core.Configuration;
 using Syringe.Core.Http;
 using Syringe.Core.Http.Logging;
 using Syringe.Core.Runner;
@@ -51,7 +52,7 @@ namespace Syringe.Tests.Unit.Core.Runner
 			};
 			httpClient.Response = response;
 
-			var runner = new TestFileRunner(httpClient, GetRepository());
+			var runner = new TestFileRunner(httpClient, GetRepository(), new JsonConfiguration());
 
 			var testFile = CreateTestFile(new[]
 			{
@@ -79,7 +80,7 @@ namespace Syringe.Tests.Unit.Core.Runner
 			response.ResponseTime = TimeSpan.FromSeconds(5);
 
 			HttpClientMock httpClient = new HttpClientMock(response);
-			var runner = new TestFileRunner(httpClient, GetRepository());
+			var runner = new TestFileRunner(httpClient, GetRepository(), new JsonConfiguration());
 
 			var testFile = CreateTestFile(new[]
 			{
@@ -367,7 +368,7 @@ namespace Syringe.Tests.Unit.Core.Runner
 				.Setup(c => c.ExecuteRequestAsync(It.IsAny<IRestRequest>(), It.IsAny<HttpLogWriter>()))
 				.Returns(Task.FromResult(new HttpResponse()));
 
-			TestFileRunner runner = new TestFileRunner(httpClientMock.Object, GetRepository());
+			TestFileRunner runner = new TestFileRunner(httpClientMock.Object, GetRepository(), new JsonConfiguration());
 
 			var testFile = CreateTestFile(new[]
 			{
@@ -424,7 +425,7 @@ namespace Syringe.Tests.Unit.Core.Runner
 				.Setup(c => c.ExecuteRequestAsync(It.IsAny<IRestRequest>(), new HttpLogWriter()))
 				.Throws(new InvalidOperationException("Bad"));
 
-			TestFileRunner runner = new TestFileRunner(httpClientMock.Object, GetRepository());
+			TestFileRunner runner = new TestFileRunner(httpClientMock.Object, GetRepository(), new JsonConfiguration());
 
 			var testFile = CreateTestFile(new[]
 			{
@@ -449,7 +450,7 @@ namespace Syringe.Tests.Unit.Core.Runner
 			_httpResponse = new HttpResponse();
 			_httpClientMock = new HttpClientMock(_httpResponse);
 
-			return new TestFileRunner(_httpClientMock, GetRepository());
+			return new TestFileRunner(_httpClientMock, GetRepository(), new JsonConfiguration());
 		}
 
 		private TestFile CreateTestFile(Test[] tests)

--- a/src/Syringe.Web/Web.config
+++ b/src/Syringe.Web/Web.config
@@ -16,7 +16,11 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.6" />
+    <compilation debug="true" targetFramework="4.6">
+      <assemblies>
+        <add assembly="System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      </assemblies>
+    </compilation>
     <httpRuntime targetFramework="4.5.1" />
     <machineKey validation="SHA1" />
     <customErrors mode="Off" />


### PR DESCRIPTION
...not 100% we should have to do this.

```CS0012: The type 'System.Object' is defined in an assembly that is
not referenced. You must add a reference to assembly 'System.Runtime,
Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.```