### PR TITLE
Changed error message to a PRE tag in the view

### DIFF
--- a/src/Syringe.Web/Scripts/Syringe/Progress.ts
+++ b/src/Syringe.Web/Scripts/Syringe/Progress.ts
@@ -46,7 +46,7 @@ module Syringe.Web {
                 // Exceptions
                 if (taskInfo.ExceptionMessage !== null) {
                     $(".test-result-exception", $selector).removeClass("hidden");
-                    $(".test-result-exception textarea", $selector).text(taskInfo.ExceptionMessage);
+                    $(".test-result-exception pre", $selector).text(taskInfo.ExceptionMessage);
                     $("table tr.result-row", $selector).addClass("warning");
                 }
                 else {

--- a/src/Syringe.Web/Views/Home/Run.cshtml
+++ b/src/Syringe.Web/Views/Home/Run.cshtml
@@ -62,12 +62,13 @@
                                             <a class="hidden view-raw btn btn-primary" target="_blank" href="@Url.Action("Edit", "Test", new {filename = Model.FileName, position = test.Position})">Edit</a>
                                         </div>
                                     </div>
-                                    <div class="test-result-errors">
-                                        <div class="hidden test-result-exception">
-                                            <h2 class="label label-danger">Error</h2>
-                                            <textarea></textarea>
-                                        </div>
-                                    </div>
+	                                <div class="test-result-errors">
+										<br />
+		                                <div class="hidden test-result-exception">
+			                                <h4>Error message</h4>
+			                                <pre></pre>
+		                                </div>
+	                                </div>
                                     <table class="table table-bordered table-striped">
                                         <tr>
                                             <td>Description</td>

--- a/src/Syringe.Web/Views/Test/View.cshtml
+++ b/src/Syringe.Web/Views/Test/View.cshtml
@@ -29,9 +29,10 @@
 
     @if (Model.Tests.Any() == false)
     {
-        <p>No test tests found.</p>}
-    else
-    {
+	    <p>No test tests found.</p>
+	}
+	else
+	{
         <table class="table table-bordered table-striped">
             <thead>
                 <tr>


### PR DESCRIPTION
New look:

![error](https://cloud.githubusercontent.com/assets/54912/15270340/dc89d130-1a13-11e6-9382-5541ab77a9de.png)
