### PR TITLE
Environment filter results

### DIFF
--- a/src/Syringe.Client/TestsClient.cs
+++ b/src/Syringe.Client/TestsClient.cs
@@ -152,7 +152,7 @@ namespace Syringe.Client
             return _restSharpHelper.DeserializeOrThrow<bool>(response);
         }
 
-        public async Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDateTime, int pageNumber = 1, int noOfResults = 20)
+        public async Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDateTime, int pageNumber = 1, int noOfResults = 20, string environment = "")
         {
             var client = new RestClient(_serviceUrl);
             IRestRequest request = _restSharpHelper.CreateRequest("GetSummaries");
@@ -160,6 +160,7 @@ namespace Syringe.Client
             request.AddQueryParameter("pageNumber", pageNumber.ToString());
             request.AddQueryParameter("noOfResults", noOfResults.ToString());
             request.AddQueryParameter("fromDateTime", fromDateTime.ToString(CultureInfo.InvariantCulture));
+            request.AddQueryParameter("environment", environment);
             IRestResponse response = await client.ExecuteGetTaskAsync(request);
             return _restSharpHelper.DeserializeOrThrow<TestFileResultSummaryCollection>(response);
         }

--- a/src/Syringe.Core/Services/ITestService.cs
+++ b/src/Syringe.Core/Services/ITestService.cs
@@ -20,7 +20,7 @@ namespace Syringe.Core.Services
 	    bool CreateTestFile(TestFile testFile);
 	    bool CopyTestFile(string sourceFileName, string targetFileName);
         bool UpdateTestVariables(TestFile testFile);
-        Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDateTime, int pageNumber = 1, int noOfResults = 20);
+        Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDateTime, int pageNumber = 1, int noOfResults = 20, string environment = "");
         TestFileResult GetResultById(Guid id);
         Task DeleteResultAsync(Guid id);
 	}

--- a/src/Syringe.Core/Tests/Results/Repositories/ITestFileResultRepository.cs
+++ b/src/Syringe.Core/Tests/Results/Repositories/ITestFileResultRepository.cs
@@ -10,6 +10,6 @@ namespace Syringe.Core.Tests.Results.Repositories
 		Task DeleteAsync(Guid testFileResultId);
 		TestFileResult GetById(Guid id);
 		void Wipe();
-        Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDateTime, int pageNumber = 1, int noOfResults = 20);
+        Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDateTime, int pageNumber = 1, int noOfResults = 20, string environment = "");
 	}
 }

--- a/src/Syringe.Core/Tests/Results/Repositories/TestFileResultRepository.cs
+++ b/src/Syringe.Core/Tests/Results/Repositories/TestFileResultRepository.cs
@@ -45,7 +45,7 @@ namespace Syringe.Core.Tests.Results.Repositories
             await _collection.Indexes.CreateOneAsync(Builders<TestFileResult>.IndexKeys.Ascending(x => x.StartTime));
             await _collection.Indexes.CreateOneAsync(Builders<TestFileResult>.IndexKeys.Ascending(x => x.Environment));
             string env = environment?.ToLower();
-            Task<long> fileResult = _collection.CountAsync(x => x.StartTime >= fromDate);
+            Task<long> fileResult = _collection.CountAsync(x => x.StartTime >= fromDate && (string.IsNullOrEmpty(environment) || x.Environment.ToLower() == env));
 
             Task<List<TestFileResult>> testFileCollection = _collection
                 .Find(x => x.StartTime >= fromDate && (string.IsNullOrEmpty(environment) || x.Environment.ToLower() == env))

--- a/src/Syringe.Core/Tests/Results/Repositories/TestFileResultRepository.cs
+++ b/src/Syringe.Core/Tests/Results/Repositories/TestFileResultRepository.cs
@@ -21,7 +21,7 @@ namespace Syringe.Core.Tests.Results.Repositories
 
             _database = mongoClient.GetDatabase(_mongoDbConfiguration.DatabaseName);
             _collection = _database.GetCollection<TestFileResult>(MONGDB_COLLECTION_NAME);
-		}
+        }
 
         public async Task AddAsync(TestFileResult testFileResult)
         {
@@ -38,17 +38,17 @@ namespace Syringe.Core.Tests.Results.Repositories
             return _collection.AsQueryable().FirstOrDefault(x => x.Id == id);
         }
 
-        public async Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDate, int pageNumber = 1, int noOfResults = 20)
+        public async Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDate, int pageNumber = 1, int noOfResults = 20, string environment = "")
         {
-			// Ensure TestFileResult has indexes on the date it was run and the environment.
-			// These index commands don't rebuild the index, they just send the command.
-			await _collection.Indexes.CreateOneAsync(Builders<TestFileResult>.IndexKeys.Ascending(x => x.StartTime));
-			await _collection.Indexes.CreateOneAsync(Builders<TestFileResult>.IndexKeys.Ascending(x => x.Environment));
+            // Ensure TestFileResult has indexes on the date it was run and the environment.
+            // These index commands don't rebuild the index, they just send the command.
+            await _collection.Indexes.CreateOneAsync(Builders<TestFileResult>.IndexKeys.Ascending(x => x.StartTime));
+            await _collection.Indexes.CreateOneAsync(Builders<TestFileResult>.IndexKeys.Ascending(x => x.Environment));
 
-			Task<long> fileResult = _collection.CountAsync(x => x.StartTime >= fromDate);
+            Task<long> fileResult = _collection.CountAsync(x => x.StartTime >= fromDate);
 
             Task<List<TestFileResult>> testFileCollection = _collection
-                .Find(x => x.StartTime >= fromDate)
+                .Find(x => x.StartTime >= fromDate && (string.IsNullOrEmpty(environment) || x.Environment.ToLower() == environment.ToLower()))
                 .Sort(Builders<TestFileResult>.Sort.Descending(x => x.StartTime))
                 .Skip((pageNumber - 1) * noOfResults)
                 .Limit(noOfResults)
@@ -73,7 +73,7 @@ namespace Syringe.Core.Tests.Results.Repositories
                         TotalFailed = x.TotalTestsFailed,
                         TotalRun = x.TotalTestsRun,
                         Environment = x.Environment,
-						Username = x.Username
+                        Username = x.Username
                     })
             };
 

--- a/src/Syringe.Core/Tests/Results/Repositories/TestFileResultRepository.cs
+++ b/src/Syringe.Core/Tests/Results/Repositories/TestFileResultRepository.cs
@@ -44,11 +44,11 @@ namespace Syringe.Core.Tests.Results.Repositories
             // These index commands don't rebuild the index, they just send the command.
             await _collection.Indexes.CreateOneAsync(Builders<TestFileResult>.IndexKeys.Ascending(x => x.StartTime));
             await _collection.Indexes.CreateOneAsync(Builders<TestFileResult>.IndexKeys.Ascending(x => x.Environment));
-
+            string env = environment?.ToLower();
             Task<long> fileResult = _collection.CountAsync(x => x.StartTime >= fromDate);
 
             Task<List<TestFileResult>> testFileCollection = _collection
-                .Find(x => x.StartTime >= fromDate && (string.IsNullOrEmpty(environment) || x.Environment.ToLower() == environment.ToLower()))
+                .Find(x => x.StartTime >= fromDate && (string.IsNullOrEmpty(environment) || x.Environment.ToLower() == env))
                 .Sort(Builders<TestFileResult>.Sort.Descending(x => x.StartTime))
                 .Skip((pageNumber - 1) * noOfResults)
                 .Limit(noOfResults)

--- a/src/Syringe.Core/Tests/Results/TestFileResultSummaryCollection.cs
+++ b/src/Syringe.Core/Tests/Results/TestFileResultSummaryCollection.cs
@@ -10,5 +10,6 @@ namespace Syringe.Core.Tests.Results
 	    public int NoOfResults { get; set; }
 	    public double PageNumbers { get; set; }
 	    public IEnumerable<string> Environments { get; set; }
+	    public string Environment { get; set; }
 	}
 }

--- a/src/Syringe.Core/Tests/Results/TestFileResultSummaryCollection.cs
+++ b/src/Syringe.Core/Tests/Results/TestFileResultSummaryCollection.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Syringe.Core.Tests.Results
 {
@@ -10,5 +9,6 @@ namespace Syringe.Core.Tests.Results
         public IEnumerable<TestFileResultSummary> PagedResults { get; set; }
 	    public int NoOfResults { get; set; }
 	    public double PageNumbers { get; set; }
+	    public IEnumerable<string> Environments { get; set; }
 	}
 }

--- a/src/Syringe.Service/Api/TestsController.cs
+++ b/src/Syringe.Service/Api/TestsController.cs
@@ -106,9 +106,9 @@ namespace Syringe.Service.Api
 
         [Route("api/tests/GetSummaries")]
         [HttpGet]
-        public Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDateTime, int pageNumber = 1, int noOfResults = 20)
+        public Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDateTime, int pageNumber = 1, int noOfResults = 20, string environment = "")
         {
-            return _testFileResultRepository.GetSummaries(fromDateTime, pageNumber, noOfResults);
+            return _testFileResultRepository.GetSummaries(fromDateTime, pageNumber, noOfResults, environment);
         }
 
         [Route("api/tests/GetById")]

--- a/src/Syringe.Tests/StubsMocks/TestCaseSessionRepositoryMock.cs
+++ b/src/Syringe.Tests/StubsMocks/TestCaseSessionRepositoryMock.cs
@@ -25,7 +25,7 @@ namespace Syringe.Tests.StubsMocks
             throw new NotImplementedException();
         }
 
-        public Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDateTime, int pageNumber = 1, int noOfResults = 20)
+        public Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDateTime, int pageNumber = 1, int noOfResults = 20, string environment = "")
         {
             return Task.FromResult(new TestFileResultSummaryCollection());
         }

--- a/src/Syringe.Tests/Unit/Web/HomeControllerTests.cs
+++ b/src/Syringe.Tests/Unit/Web/HomeControllerTests.cs
@@ -40,8 +40,6 @@ namespace Syringe.Tests.Unit.Web
 
             _testsClient = new Mock<ITestService>();
             _testsClient.Setup(x => x.GetResultById(It.IsAny<Guid>())).Returns(new TestFileResult());
-            _testsClient.Setup(x => x.GetSummaries(It.IsAny<DateTime>(),It.IsAny<int>(), It.IsAny<int>(),It.IsAny<string>())).Returns(Task.FromResult(new TestFileResultSummaryCollection()));
-
             _homeController = new HomeController(_testsClient.Object, _runViewModelFactory.Object, _mockHealthCheck, _environmentService.Object, _configuration);
         }
 

--- a/src/Syringe.Tests/Unit/Web/HomeControllerTests.cs
+++ b/src/Syringe.Tests/Unit/Web/HomeControllerTests.cs
@@ -40,7 +40,7 @@ namespace Syringe.Tests.Unit.Web
 
             _testsClient = new Mock<ITestService>();
             _testsClient.Setup(x => x.GetResultById(It.IsAny<Guid>())).Returns(new TestFileResult());
-            _testsClient.Setup(x => x.GetSummaries(It.IsAny<DateTime>(),It.IsAny<int>(), It.IsAny<int>())).Returns(Task.FromResult(new TestFileResultSummaryCollection()));
+            _testsClient.Setup(x => x.GetSummaries(It.IsAny<DateTime>(),It.IsAny<int>(), It.IsAny<int>(),It.IsAny<string>())).Returns(Task.FromResult(new TestFileResultSummaryCollection()));
 
             _homeController = new HomeController(_testsClient.Object, _runViewModelFactory.Object, _mockHealthCheck, _environmentService.Object, _configuration);
         }

--- a/src/Syringe.Tests/Unit/Web/ResultsControllerTests.cs
+++ b/src/Syringe.Tests/Unit/Web/ResultsControllerTests.cs
@@ -21,6 +21,7 @@ namespace Syringe.Tests.Unit.Web
         private Mock<ITasksService> _tasksServiceMock;
         private Mock<IUrlHelper> _urlHelperMock;
         private Mock<ITestService> _testsClient;
+        private Mock<IEnvironmentsService> _environmentServiceClient;
 
         private ResultsController _resultsController;
 
@@ -30,13 +31,14 @@ namespace Syringe.Tests.Unit.Web
             _id = 0;
             _tasksServiceMock = new Mock<ITasksService>();
             _urlHelperMock = new Mock<IUrlHelper>();
+            _environmentServiceClient = new Mock<IEnvironmentsService>();
 
             _testsClient = new Mock<ITestService>();
             _testsClient.Setup(x => x.GetResultById(It.IsAny<Guid>())).Returns(new TestFileResult());
-            _testsClient.Setup(x => x.GetSummaries(It.IsAny<DateTime>(),It.IsAny<int>(), It.IsAny<int>())).Returns(Task.FromResult(new TestFileResultSummaryCollection()));
+            _testsClient.Setup(x => x.GetSummaries(It.IsAny<DateTime>(),It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>())).Returns(Task.FromResult(new TestFileResultSummaryCollection()));
 
             _tasksServiceMock.Setup(x => x.GetRunningTaskDetails(It.IsAny<int>())).Returns((new TaskDetails { Results = new List<TestResult> { new TestResult { ActualUrl = "syringe.com", Position = _id } } }));
-            _resultsController = new ResultsController(_tasksServiceMock.Object, _urlHelperMock.Object, _testsClient.Object);
+            _resultsController = new ResultsController(_tasksServiceMock.Object, _urlHelperMock.Object, _testsClient.Object, _environmentServiceClient.Object);
         }
 
         [Test]
@@ -97,7 +99,7 @@ namespace Syringe.Tests.Unit.Web
             var viewResult = _resultsController.Index().Result as ViewResult;
 
             // then
-            _testsClient.Verify(x => x.GetSummaries(It.IsAny<DateTime>(),It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+            _testsClient.Verify(x => x.GetSummaries(It.IsAny<DateTime>(),It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()), Times.Once);
             Assert.AreEqual("Index", viewResult.ViewName);
             Assert.IsInstanceOf<TestFileResultSummaryCollection>(viewResult.Model);
         }
@@ -109,7 +111,7 @@ namespace Syringe.Tests.Unit.Web
             var viewResult = _resultsController.Today().Result as ViewResult;
 
             // then
-            _testsClient.Verify(x => x.GetSummaries(It.IsAny<DateTime>(),It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+            _testsClient.Verify(x => x.GetSummaries(It.IsAny<DateTime>(),It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()), Times.Once);
             Assert.AreEqual("Index", viewResult.ViewName);
             Assert.IsInstanceOf<TestFileResultSummaryCollection>(viewResult.Model);
         }

--- a/src/Syringe.Tests/Unit/Web/ResultsControllerTests.cs
+++ b/src/Syringe.Tests/Unit/Web/ResultsControllerTests.cs
@@ -11,6 +11,7 @@ using Syringe.Core.Tasks;
 using Syringe.Core.Tests.Results;
 using Syringe.Web.Controllers;
 using Syringe.Web.Models;
+using Environment = Syringe.Core.Environment.Environment;
 
 namespace Syringe.Tests.Unit.Web
 {
@@ -35,7 +36,7 @@ namespace Syringe.Tests.Unit.Web
 
             _testsClient = new Mock<ITestService>();
             _testsClient.Setup(x => x.GetResultById(It.IsAny<Guid>())).Returns(new TestFileResult());
-            _testsClient.Setup(x => x.GetSummaries(It.IsAny<DateTime>(),It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>())).Returns(Task.FromResult(new TestFileResultSummaryCollection()));
+            _testsClient.Setup(x => x.GetSummaries(It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>())).Returns(Task.FromResult(new TestFileResultSummaryCollection()));
 
             _tasksServiceMock.Setup(x => x.GetRunningTaskDetails(It.IsAny<int>())).Returns((new TaskDetails { Results = new List<TestResult> { new TestResult { ActualUrl = "syringe.com", Position = _id } } }));
             _resultsController = new ResultsController(_tasksServiceMock.Object, _urlHelperMock.Object, _testsClient.Object, _environmentServiceClient.Object);
@@ -46,7 +47,7 @@ namespace Syringe.Tests.Unit.Web
         {
             // given
             _tasksServiceMock.Setup(x => x.GetRunningTaskDetails(It.IsAny<int>())).Returns((new TaskDetails { Results = new List<TestResult>() }));
-            
+
             // when
             var actionResult = _resultsController.Html(It.IsAny<int>(), It.IsAny<int>()) as HttpStatusCodeResult;
 
@@ -63,7 +64,7 @@ namespace Syringe.Tests.Unit.Web
 
             // then
             Assert.IsInstanceOf<ResultsViewModel>(actionResult.Model);
-            _tasksServiceMock.Verify(x=>x.GetRunningTaskDetails(It.IsAny<int>()),Times.Once);
+            _tasksServiceMock.Verify(x => x.GetRunningTaskDetails(It.IsAny<int>()), Times.Once);
         }
 
         [Test]
@@ -99,8 +100,9 @@ namespace Syringe.Tests.Unit.Web
             var viewResult = _resultsController.Index().Result as ViewResult;
 
             // then
-            _testsClient.Verify(x => x.GetSummaries(It.IsAny<DateTime>(),It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()), Times.Once);
+            _testsClient.Verify(x => x.GetSummaries(It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()), Times.Once);
             Assert.AreEqual("Index", viewResult.ViewName);
+            Assert.AreEqual(viewResult.ViewBag.Title, "All results");
             Assert.IsInstanceOf<TestFileResultSummaryCollection>(viewResult.Model);
         }
 
@@ -111,8 +113,9 @@ namespace Syringe.Tests.Unit.Web
             var viewResult = _resultsController.Today().Result as ViewResult;
 
             // then
-            _testsClient.Verify(x => x.GetSummaries(It.IsAny<DateTime>(),It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()), Times.Once);
+            _testsClient.Verify(x => x.GetSummaries(It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>()), Times.Once);
             Assert.AreEqual("Index", viewResult.ViewName);
+            Assert.AreEqual(viewResult.ViewBag.Title, "Today's results");
             Assert.IsInstanceOf<TestFileResultSummaryCollection>(viewResult.Model);
         }
 

--- a/src/Syringe.Web/Controllers/ResultsController.cs
+++ b/src/Syringe.Web/Controllers/ResultsController.cs
@@ -17,12 +17,14 @@ namespace Syringe.Web.Controllers
         private readonly ITasksService _tasksClient;
         private readonly IUrlHelper _urlHelper;
         private readonly ITestService _testsClient;
+	    private readonly IEnvironmentsService _environmentsService;
 
-        public ResultsController(ITasksService tasksClient, IUrlHelper urlHelper, ITestService testsClient)
+	    public ResultsController(ITasksService tasksClient, IUrlHelper urlHelper, ITestService testsClient, IEnvironmentsService environmentsService)
         {
             _tasksClient = tasksClient;
             _urlHelper = urlHelper;
             _testsClient = testsClient;
+	        _environmentsService = environmentsService;
         }
 
         public ActionResult Html(int taskId, int position)
@@ -71,19 +73,21 @@ namespace Syringe.Web.Controllers
             return View(viewModel);
         }
 
-        public async Task<ActionResult> Index(int pageNumber = 1, int noOfResults = 20)
+        public async Task<ActionResult> Index(int pageNumber = 1, int noOfResults = 20, string environment="")
         {
 	        ViewBag.Title = "All results";
 
-            TestFileResultSummaryCollection result = await _testsClient.GetSummaries(DateTime.Today.AddYears(-1), pageNumber, noOfResults);
+            TestFileResultSummaryCollection result = await _testsClient.GetSummaries(DateTime.Today.AddYears(-1), pageNumber, noOfResults, environment);
+            result.Environments = _environmentsService.List().OrderBy(x => x.Order).ThenBy(x => x.Name).Select(x => x.Name).ToArray();
             return View("Index", result);
         }
 
-        public async Task<ActionResult> Today(int pageNumber = 1, int noOfResults = 20)
+        public async Task<ActionResult> Today(int pageNumber = 1, int noOfResults = 20, string environment = "")
         {
 			ViewBag.Title = "Today's results";
 
-			TestFileResultSummaryCollection result = await _testsClient.GetSummaries(DateTime.Today, pageNumber, noOfResults);
+			TestFileResultSummaryCollection result = await _testsClient.GetSummaries(DateTime.Today, pageNumber, noOfResults, environment);
+            result.Environments = _environmentsService.List().OrderBy(x => x.Order).ThenBy(x => x.Name).Select(x => x.Name).ToArray();
             return View("Index", result);
         }
 

--- a/src/Syringe.Web/Controllers/ResultsController.cs
+++ b/src/Syringe.Web/Controllers/ResultsController.cs
@@ -11,20 +11,20 @@ using Syringe.Web.Models;
 
 namespace Syringe.Web.Controllers
 {
-	[AuthorizeWhenOAuth]
-	public class ResultsController : Controller
+    [AuthorizeWhenOAuth]
+    public class ResultsController : Controller
     {
         private readonly ITasksService _tasksClient;
         private readonly IUrlHelper _urlHelper;
         private readonly ITestService _testsClient;
-	    private readonly IEnvironmentsService _environmentsService;
+        private readonly IEnvironmentsService _environmentsService;
 
-	    public ResultsController(ITasksService tasksClient, IUrlHelper urlHelper, ITestService testsClient, IEnvironmentsService environmentsService)
+        public ResultsController(ITasksService tasksClient, IUrlHelper urlHelper, ITestService testsClient, IEnvironmentsService environmentsService)
         {
             _tasksClient = tasksClient;
             _urlHelper = urlHelper;
             _testsClient = testsClient;
-	        _environmentsService = environmentsService;
+            _environmentsService = environmentsService;
         }
 
         public ActionResult Html(int taskId, int position)
@@ -73,21 +73,23 @@ namespace Syringe.Web.Controllers
             return View(viewModel);
         }
 
-        public async Task<ActionResult> Index(int pageNumber = 1, int noOfResults = 20, string environment="")
+        public async Task<ActionResult> Index(int pageNumber = 1, int noOfResults = 20, string environment = "")
         {
-	        ViewBag.Title = "All results";
+            ViewBag.Title = "All results";
 
             TestFileResultSummaryCollection result = await _testsClient.GetSummaries(DateTime.Today.AddYears(-1), pageNumber, noOfResults, environment);
             result.Environments = _environmentsService.List().OrderBy(x => x.Order).ThenBy(x => x.Name).Select(x => x.Name).ToArray();
+            result.Environment = environment;
             return View("Index", result);
         }
 
         public async Task<ActionResult> Today(int pageNumber = 1, int noOfResults = 20, string environment = "")
         {
-			ViewBag.Title = "Today's results";
+            ViewBag.Title = "Today's results";
 
-			TestFileResultSummaryCollection result = await _testsClient.GetSummaries(DateTime.Today, pageNumber, noOfResults, environment);
+            TestFileResultSummaryCollection result = await _testsClient.GetSummaries(DateTime.Today, pageNumber, noOfResults, environment);
             result.Environments = _environmentsService.List().OrderBy(x => x.Order).ThenBy(x => x.Name).Select(x => x.Name).ToArray();
+            result.Environment = environment;
             return View("Index", result);
         }
 

--- a/src/Syringe.Web/Views/Results/Index.cshtml
+++ b/src/Syringe.Web/Views/Results/Index.cshtml
@@ -11,9 +11,10 @@
 
                 <div class="col-xs-2">
                     <div class="btn-group">
-                        <button type="button" class="btn btn-danger dropdown-toggle" data-toggle="dropdown">Environment</button>
+                        <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown">Environment</button>
 
                         <ul class="dropdown-menu dropdown-menu-right">
+                            <li><a href="@Url.Action("Index", "Results", new {pageNumber = 1, noOfResults = Model.NoOfResults})">All</a></li>
                             @foreach (string environment in Model.Environments)
                             {
                                 <li><a href="@Url.Action("Index", "Results", new {pageNumber = 1, noOfResults = Model.NoOfResults, environment})">@environment</a></li>

--- a/src/Syringe.Web/Views/Results/Index.cshtml
+++ b/src/Syringe.Web/Views/Results/Index.cshtml
@@ -4,52 +4,70 @@
     <div class="row">
         <div class="col-xs-12">
             <h2>@ViewBag.Title</h2>
+            <div class="row">
+                <div class="col-xs-10">
+                    @Html.Partial("Partials/_ResultsPager")
+                </div>
+
+                <div class="col-xs-2">
+                    <div class="btn-group">
+                        <button type="button" class="btn btn-danger dropdown-toggle" data-toggle="dropdown">Environment</button>
+
+                        <ul class="dropdown-menu dropdown-menu-right">
+                            @foreach (string environment in Model.Environments)
+                            {
+                                <li><a href="@Url.Action("Index", "Results", new {pageNumber = 1, noOfResults = Model.NoOfResults, environment})">@environment</a></li>
+                            }
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+
+            @foreach (var groupedSummary in Model.PagedResults.GroupBy(x => x.Environment).OrderBy(x => x.Key))
+            {
+                <br />
+                    <div class="label label-material-indigo">@groupedSummary.Key</div>
+                    <table class="table table-bordered table-striped">
+                        <thead>
+                            <tr>
+                                <th>Date and user</th>
+                                <td>Name</td>
+                                <td>Result</td>
+                                <td></td>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (TestFileResultSummary summary in groupedSummary)
+                            {
+                                string className = "success";
+                                if (summary.TotalFailed > 0)
+                                {
+                                    className = "danger";
+                                }
+
+                                <tr class="@className">
+                                    <td>
+                                        @summary.DateRun.ToLocalTime().ToString("ddd dd MMMM HH:mm") <br />
+                                        <em>Ran by @summary.Username</em>
+                                    </td>
+                                    <td>
+                                        @summary.FileName
+                                    </td>
+                                    <td>
+                                        <span class="label label-success results-label">Total Passed: @summary.TotalPassed</span>
+                                        <span class="label label-danger results-label">Total Failed: @summary.TotalFailed</span>
+                                        <span class="label label-info results-label">Run Time: @summary.TotalRunTime.MinutesAndSecondsFormat()</span>
+                                    </td>
+                                    <td>
+                                        <a class="btn btn-sm btn-primary" href="@Url.Action("ViewResult", "Results", new {id = summary.Id})">View</a>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+            }
             @Html.Partial("Partials/_ResultsPager")
-
-			@foreach (var groupedSummary in Model.PagedResults.GroupBy(x => x.Environment).OrderBy(x => x.Key))
-			{
-				<br/>
-				<div class="label label-material-indigo">@groupedSummary.Key</div>
-				<table class="table table-bordered table-striped">
-					<thead>
-					<tr>
-						<th>Date and user</th>
-						<td>Name</td>
-						<td>Result</td>
-						<td></td>
-					</tr>
-					</thead>
-					<tbody>
-					@foreach (TestFileResultSummary summary in groupedSummary)
-					{
-						string className = "success";
-						if (summary.TotalFailed > 0)
-						{
-							className = "danger";
-						}
-
-						<tr class="@className">
-							<td>
-								@summary.DateRun.ToLocalTime().ToString("ddd dd MMMM HH:mm") <br/>
-								<em>Ran by @summary.Username</em>
-							</td>
-							<td>
-								@summary.FileName
-							</td>
-							<td>
-								<span class="label label-success results-label">Total Passed: @summary.TotalPassed</span>
-								<span class="label label-danger results-label">Total Failed: @summary.TotalFailed</span>
-								<span class="label label-info results-label">Run Time: @summary.TotalRunTime.MinutesAndSecondsFormat()</span>
-							</td>
-							<td>
-								<a class="btn btn-sm btn-primary" href="@Url.Action("ViewResult", "Results", new {id = summary.Id})">View</a>
-							</td>
-						</tr>
-					}
-					</tbody>
-				</table>
-			}
-           @Html.Partial("Partials/_ResultsPager")
         </div>
     </div>
 </div>

--- a/src/Syringe.Web/Views/Results/Index.cshtml
+++ b/src/Syringe.Web/Views/Results/Index.cshtml
@@ -27,8 +27,7 @@
 
             @foreach (var groupedSummary in Model.PagedResults.GroupBy(x => x.Environment).OrderBy(x => x.Key))
             {
-                <br />
-                    <div class="label label-material-indigo">@groupedSummary.Key</div>
+                <div class="label label-material-indigo">@groupedSummary.Key</div>
                     <table class="table table-bordered table-striped">
                         <thead>
                             <tr>

--- a/src/Syringe.Web/Views/Shared/Partials/_ResultsPager.cshtml
+++ b/src/Syringe.Web/Views/Shared/Partials/_ResultsPager.cshtml
@@ -5,7 +5,7 @@
     <ul class="pagination">
         @for (int i = 1; i <= Model.PageNumbers; i++)
         {
-            <li class=@(Model.PageNumber == i ? "active" : "")><a href="@Url.Action("Index", "Results", new {pageNumber = i, noOfResults = Model.NoOfResults})">@i</a></li>
+            <li class=@(Model.PageNumber == i ? "active" : "")><a href="@Url.Action("Index", "Results", new {pageNumber = i, noOfResults = Model.NoOfResults, environment=Model.Environment})">@i</a></li>
         }
     </ul>
 }


### PR DESCRIPTION
This addresses issue #164. Results can be filtered by environment

No cookie/local storage to persist the environment just yet, but that can be added in later.

@Workshop2  @yetanotherchris 