### PR TITLE
Validate correctly if you leave the description and value fields blank

### DIFF
--- a/src/Syringe.Tests/Unit/Web/ValidationAttributes/ValidationAttributesTests.cs
+++ b/src/Syringe.Tests/Unit/Web/ValidationAttributes/ValidationAttributesTests.cs
@@ -25,5 +25,11 @@ namespace Syringe.Tests.Unit.Web.ValidationAttributes
         {
             Assert.IsTrue(new ValidRegexAttribute().IsValid(regex));
         }
+
+        [Test]
+        public void IsValid_should_return_false_when_AssertionTypeValidation_value_is_null()
+        {
+            Assert.IsFalse(new AssertionTypeValidationAttribute().IsValid(null));
+        }
     }
 }

--- a/src/Syringe.Web/Models/ValidationAttributes/AssertionTypeValidationAttribute.cs
+++ b/src/Syringe.Web/Models/ValidationAttributes/AssertionTypeValidationAttribute.cs
@@ -12,6 +12,9 @@ namespace Syringe.Web.Models.ValidationAttributes
         {
             var model = (AssertionViewModel)context.ObjectInstance;
 
+            if (value == null)
+                return new ValidationResult("This field is mandatory");
+
             // replace variables so they don't interfere with validation
             value = ReplaceVariables(value.ToString());
 

--- a/src/Syringe.Web/Models/ValidationAttributes/AssertionTypeValidationAttribute.cs
+++ b/src/Syringe.Web/Models/ValidationAttributes/AssertionTypeValidationAttribute.cs
@@ -10,13 +10,13 @@ namespace Syringe.Web.Models.ValidationAttributes
 
         protected override ValidationResult IsValid(object value, ValidationContext context)
         {
-            var model = (AssertionViewModel)context.ObjectInstance;
-
             if (value == null)
                 return new ValidationResult("This field is mandatory");
 
             // replace variables so they don't interfere with validation
             value = ReplaceVariables(value.ToString());
+
+            var model = (AssertionViewModel)context.ObjectInstance;
 
             if (model.AssertionMethod == AssertionMethod.CssSelector)
             {
@@ -32,7 +32,6 @@ namespace Syringe.Web.Models.ValidationAttributes
             //no assertion type so always valid
             return ValidationResult.Success;
         }
-
 
         private static string ReplaceVariables(string value)
         {


### PR DESCRIPTION
To recreate, add an assertion to an existing test but don't enter any text in the Description or Value fields