### PR TITLE
Required version to edit

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -42,6 +42,13 @@ choco install nodejs -y
 # Refresh the path vars for npm (Chocolatey 0.98+)
 refreshenv
 
+# try and stop the service if it's installed
+$servicePath = ".\src\Syringe.Service\bin\release\Syringe.Service.exe"
+if(Test-Path $servicePath)
+{
+    & $servicePath stop
+}
+
 try
 {
     pushd src\Syringe.Web

--- a/src/Syringe.Client/TestsClient.cs
+++ b/src/Syringe.Client/TestsClient.cs
@@ -177,7 +177,7 @@ namespace Syringe.Client
             return _restSharpHelper.DeserializeOrThrow<bool>(response);
         }
 
-        public bool Reorder(string fileName, IEnumerable<TestPosition> tests)
+        public bool ReorderTests(string fileName, IEnumerable<TestPosition> tests)
         {
             var client = new RestClient(ServiceUrl);
 

--- a/src/Syringe.Core/Configuration/IConfiguration.cs
+++ b/src/Syringe.Core/Configuration/IConfiguration.cs
@@ -6,6 +6,7 @@ namespace Syringe.Core.Configuration
 	{
 		string ServiceUrl { get; }
 		string WebsiteUrl { get; }
+        int EngineVersion { get; }
 		string TestFilesBaseDirectory { get; }
 		OAuthConfiguration OAuthConfiguration { get; }
         OctopusConfiguration OctopusConfiguration { get; }

--- a/src/Syringe.Core/Configuration/JsonConfiguration.cs
+++ b/src/Syringe.Core/Configuration/JsonConfiguration.cs
@@ -12,7 +12,9 @@ namespace Syringe.Core.Configuration
 		[JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
 		public string WebsiteUrl { get; set; }
 
-		[JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+	    public int EngineVersion { get; } = 1; // update this when new features are released
+
+	    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
 		public string TestFilesBaseDirectory { get; set; }
         
 		public OAuthConfiguration OAuthConfiguration { get; set; }
@@ -36,7 +38,7 @@ namespace Syringe.Core.Configuration
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public TimeSpan CleanupSchedule { get; set; }
-
+        
         public JsonConfiguration()
 		{
 			// Defaults

--- a/src/Syringe.Core/Exceptions/HealthCheckException.cs
+++ b/src/Syringe.Core/Exceptions/HealthCheckException.cs
@@ -4,12 +4,10 @@ namespace Syringe.Core.Exceptions
 {
 	public class HealthCheckException : Exception
 	{
-		public HealthCheckException(string message, string name) : base(message)
-		{
-		}
+		public HealthCheckException(string message) : base(message)
+		{ }
 
 		public HealthCheckException(string message, params object[] args) : base(string.Format(message, args))
-		{
-		}
+		{ }
 	}
 }

--- a/src/Syringe.Core/Exceptions/InvalidEngineException.cs
+++ b/src/Syringe.Core/Exceptions/InvalidEngineException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Syringe.Core.Exceptions
+{
+    public class InvalidEngineException : Exception
+    {
+        public InvalidEngineException(string message) : base(message)
+		{ }
+
+        public InvalidEngineException(string message, params object[] args) : base(string.Format(message, args))
+		{ }
+    }
+}

--- a/src/Syringe.Core/Services/ITestService.cs
+++ b/src/Syringe.Core/Services/ITestService.cs
@@ -22,6 +22,6 @@ namespace Syringe.Core.Services
         Task<TestFileResultSummaryCollection> GetSummaries(DateTime fromDateTime, int pageNumber = 1, int noOfResults = 20, string environment = "");
         TestFileResult GetResultById(Guid id);
         bool DeleteResult(Guid id);
-	    bool Reorder(string fileName, IEnumerable<TestPosition> tests);
+	    bool ReorderTests(string fileName, IEnumerable<TestPosition> tests);
 	}
 }

--- a/src/Syringe.Core/Syringe.Core.csproj
+++ b/src/Syringe.Core/Syringe.Core.csproj
@@ -216,6 +216,7 @@
     <Compile Include="Runner\Messaging\IMessage.cs" />
     <Compile Include="Runner\Messaging\TestResultMessage.cs" />
     <Compile Include="Runner\TestFileRunnerFactory.cs" />
+    <Compile Include="Exceptions\InvalidEngineException.cs" />
     <Compile Include="Tests\Results\Repositories\ITestFileResultRepositoryFactory.cs" />
     <Compile Include="Tests\Results\Repositories\MongoTestFileResultRepository.cs" />
     <Compile Include="Tests\Results\Repositories\TestFileResultRepositoryFactory.cs" />

--- a/src/Syringe.Core/Tests/Repositories/ITestRepository.cs
+++ b/src/Syringe.Core/Tests/Repositories/ITestRepository.cs
@@ -12,8 +12,8 @@ namespace Syringe.Core.Tests.Repositories
         bool DeleteTest(int position, string filename);
         bool CreateTestFile(TestFile testFile);
         bool UpdateTestVariables(TestFile testFile);
+        bool UpdateTests(TestFile testFile);
         string GetRawFile(string filename);
         bool DeleteFile(string filename);
-        bool Reorder(string filename, IEnumerable<TestPosition> tests);
     }
 }

--- a/src/Syringe.Core/Tests/Repositories/TestRepository.cs
+++ b/src/Syringe.Core/Tests/Repositories/TestRepository.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Syringe.Core.Configuration;
 using Syringe.Core.IO;
 
 namespace Syringe.Core.Tests.Repositories
@@ -11,12 +12,14 @@ namespace Syringe.Core.Tests.Repositories
         private readonly ITestFileReader _testFileReader;
         private readonly ITestFileWriter _testFileWriter;
         private readonly IFileHandler _fileHandler;
+        private readonly IConfiguration _configuration;
 
-        public TestRepository(ITestFileReader testFileReader, ITestFileWriter testFileWriter, IFileHandler fileHandler)
+        public TestRepository(ITestFileReader testFileReader, ITestFileWriter testFileWriter, IFileHandler fileHandler, IConfiguration configuration)
         {
             _testFileReader = testFileReader;
             _testFileWriter = testFileWriter;
             _fileHandler = fileHandler;
+            _configuration = configuration;
         }
 
         public Test GetTest(string filename, int position)
@@ -154,6 +157,8 @@ namespace Syringe.Core.Tests.Repositories
 
         private bool SaveTestFile(TestFile testFile, string fileFullPath)
         {
+            testFile.EngineVersion = _configuration.EngineVersion;
+
             string contents = _testFileWriter.Write(testFile);
             return _fileHandler.WriteAllText(fileFullPath, contents);
         }

--- a/src/Syringe.Core/Tests/Repositories/TestRepository.cs
+++ b/src/Syringe.Core/Tests/Repositories/TestRepository.cs
@@ -147,6 +147,22 @@ namespace Syringe.Core.Tests.Repositories
             }
         }
 
+        public bool UpdateTests(TestFile testFile)
+        {
+            string fileFullPath = _fileHandler.GetFileFullPath(testFile.Filename);
+            string fileContents = _fileHandler.ReadAllText(fileFullPath);
+
+            using (var stringReader = new StringReader(fileContents))
+            {
+                TestFile updatedTestFile = _testFileReader.Read(stringReader);
+
+                updatedTestFile.Tests = testFile.Tests;
+
+                string contents = _testFileWriter.Write(updatedTestFile);
+                return _fileHandler.WriteAllText(fileFullPath, contents);
+            }
+        }
+
         public TestFile GetTestFile(string filename)
         {
             string fullPath = _fileHandler.GetFileFullPath(filename);
@@ -172,38 +188,6 @@ namespace Syringe.Core.Tests.Repositories
             var fullPath = _fileHandler.GetFileFullPath(filename);
             return _fileHandler.DeleteFile(fullPath);
         }
-
-        public bool Reorder(string filename, IEnumerable<TestPosition> tests)
-        {
-            string fullPath = _fileHandler.GetFileFullPath(filename);
-            string fileContents = _fileHandler.ReadAllText(fullPath);
-
-            using (var stringReader = new StringReader(fileContents))
-            {
-                TestFile testFile = _testFileReader.Read(stringReader);
-                testFile.Filename = filename;
-
-                var newOrderList = new List<Test>();
-
-                List<TestPosition> testPositions = tests.ToList();
-                for (int i = 0; i < testPositions.Count; i++)
-                {
-                    var test = testPositions[i];
-                    newOrderList.Add(testFile.Tests.ElementAtOrDefault(test.OriginalPostion));
-                }
-
-                TestFile reorderedTestFile = new TestFile
-                {
-                    Filename = filename,
-                    Tests = newOrderList
-                };
-
-                string contents = _testFileWriter.Write(reorderedTestFile);
-
-                return _fileHandler.WriteAllText(fullPath, contents);
-            }
-        }
-
 
         public IEnumerable<string> ListFiles()
         {

--- a/src/Syringe.Core/Tests/Repositories/TestRepository.cs
+++ b/src/Syringe.Core/Tests/Repositories/TestRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Syringe.Core.Configuration;
+using Syringe.Core.Exceptions;
 using Syringe.Core.IO;
 
 namespace Syringe.Core.Tests.Repositories
@@ -157,6 +158,11 @@ namespace Syringe.Core.Tests.Repositories
 
         private bool SaveTestFile(TestFile testFile, string fileFullPath)
         {
+            if (testFile.EngineVersion > _configuration.EngineVersion)
+            {
+                throw new InvalidEngineException("The file you are trying to save was built with a newer version of Syringe. Please update your copy of Syringe.");
+            }
+
             testFile.EngineVersion = _configuration.EngineVersion;
 
             string contents = _testFileWriter.Write(testFile);

--- a/src/Syringe.Core/Tests/Repositories/TestRepository.cs
+++ b/src/Syringe.Core/Tests/Repositories/TestRepository.cs
@@ -43,18 +43,16 @@ namespace Syringe.Core.Tests.Repositories
             string fullPath = _fileHandler.GetFileFullPath(filename);
             string fileContents = _fileHandler.ReadAllText(fullPath);
 
-            TestFile collection;
+            TestFile testFile;
 
             using (var stringReader = new StringReader(fileContents))
             {
-                collection = _testFileReader.Read(stringReader);
+                testFile = _testFileReader.Read(stringReader);
 
-                collection.Tests = collection.Tests.Concat(new[] { test });
+                testFile.Tests = testFile.Tests.Concat(new[] { test });
             }
 
-            string contents = _testFileWriter.Write(collection);
-
-            return _fileHandler.WriteAllText(fullPath, contents);
+            return SaveTestFile(testFile, fullPath);
         }
 
         public bool SaveTest(string filename, int position, Test test)
@@ -83,9 +81,7 @@ namespace Syringe.Core.Tests.Repositories
             singleTest.ScriptSnippets = test.ScriptSnippets;
             singleTest.TestConditions = test.TestConditions;
 
-            string contents = _testFileWriter.Write(testFile);
-
-            return _fileHandler.WriteAllText(fullPath, contents);
+            return SaveTestFile(testFile, fullPath);
         }
 
         public bool DeleteTest(int position, string filename)
@@ -109,26 +105,22 @@ namespace Syringe.Core.Tests.Repositories
                 testFile.Tests = testFile.Tests.Where(x => x != testToDelete);
             }
 
-            string contents = _testFileWriter.Write(testFile);
-
-            return _fileHandler.WriteAllText(fullPath, contents);
+            return SaveTestFile(testFile, fullPath);
         }
 
         public bool CreateTestFile(TestFile testFile)
         {
             testFile.Filename = _fileHandler.GetFilenameWithExtension(testFile.Filename);
 
-            string filePath = _fileHandler.CreateFileFullPath(testFile.Filename);
-            bool fileExists = _fileHandler.FileExists(filePath);
+            string fullPath = _fileHandler.CreateFileFullPath(testFile.Filename);
+            bool fileExists = _fileHandler.FileExists(fullPath);
 
             if (fileExists)
             {
                 throw new IOException("File already exists");
             }
 
-            string contents = _testFileWriter.Write(testFile);
-
-            return _fileHandler.WriteAllText(filePath, contents);
+            return SaveTestFile(testFile, fullPath);
         }
 
         public bool UpdateTestVariables(TestFile testFile)
@@ -142,8 +134,7 @@ namespace Syringe.Core.Tests.Repositories
 
                 updatedTestFile.Variables = testFile.Variables;
 
-                string contents = _testFileWriter.Write(updatedTestFile);
-                return _fileHandler.WriteAllText(fileFullPath, contents);
+                return SaveTestFile(updatedTestFile, fileFullPath);
             }
         }
 
@@ -155,12 +146,16 @@ namespace Syringe.Core.Tests.Repositories
             using (var stringReader = new StringReader(fileContents))
             {
                 TestFile updatedTestFile = _testFileReader.Read(stringReader);
-
                 updatedTestFile.Tests = testFile.Tests;
 
-                string contents = _testFileWriter.Write(updatedTestFile);
-                return _fileHandler.WriteAllText(fileFullPath, contents);
+                return SaveTestFile(updatedTestFile, fileFullPath);
             }
+        }
+
+        private bool SaveTestFile(TestFile testFile, string fileFullPath)
+        {
+            string contents = _testFileWriter.Write(testFile);
+            return _fileHandler.WriteAllText(fileFullPath, contents);
         }
 
         public TestFile GetTestFile(string filename)

--- a/src/Syringe.Core/Tests/TestFile.cs
+++ b/src/Syringe.Core/Tests/TestFile.cs
@@ -8,6 +8,7 @@ namespace Syringe.Core.Tests
 		public IEnumerable<Test> Tests { get; set; }
 		public string Filename { get; set; }
 		public List<Variable> Variables { get; set; }
+	    public int EngineVersion { get; set; }
 
 	    public TestFile()
 		{

--- a/src/Syringe.Core/Tests/TestPosition.cs
+++ b/src/Syringe.Core/Tests/TestPosition.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Syringe.Core.Tests
+﻿namespace Syringe.Core.Tests
 {
     public class TestPosition
     {
         public int OriginalPostion { get; set; }
-        public string Description { get; set; }
     }
 }

--- a/src/Syringe.Service/Controllers/TestsController.cs
+++ b/src/Syringe.Service/Controllers/TestsController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Syringe.Core.Services;
@@ -13,7 +14,7 @@ namespace Syringe.Service.Controllers
 	public class TestsController : ApiController, ITestService
     {
         private readonly ITestRepository _testRepository;
-        internal readonly ITestFileResultRepository _testFileResultRepository;
+        private readonly ITestFileResultRepository _testFileResultRepository;
 
         public TestsController(ITestRepository testRepository, ITestFileResultRepository testFileResultRepository)
         {
@@ -128,9 +129,21 @@ namespace Syringe.Service.Controllers
 
 	    [Route("api/test/reorder")]
         [HttpPost]
-        public bool Reorder(string fileName, [FromBody]IEnumerable<TestPosition> tests)
-	    {
-            return _testRepository.Reorder(fileName, tests);
+        public bool ReorderTests(string fileName, [FromBody]IEnumerable<TestPosition> tests)
+        {
+            TestFile testFile = _testRepository.GetTestFile(fileName);
+
+            var newOrderList = new List<Test>();
+
+            List<TestPosition> testPositions = tests.ToList();
+            foreach (var test in testPositions)
+            {
+                newOrderList.Add(testFile.Tests.ElementAtOrDefault(test.OriginalPostion));
+            }
+
+            testFile.Tests = newOrderList;
+            
+            return _testRepository.UpdateTests(testFile);
         }
     }
 }

--- a/src/Syringe.Tests/Integration/ClientAndService/TestsClientTests.cs
+++ b/src/Syringe.Tests/Integration/ClientAndService/TestsClientTests.cs
@@ -305,5 +305,31 @@ namespace Syringe.Tests.Integration.ClientAndService
             Assert.True(success);
             Assert.False(File.Exists(fullPath));
         }
+
+        [Test]
+        public void ReorderTests_should_change_ordering_of_tests_on_disk()
+        {
+            // given
+            TestsClient client = Helpers.CreateTestsClient();
+            TestFile testFile = Helpers.CreateTestFileAndTest(client);
+            var reorder = new List<TestPosition>
+            {
+                new TestPosition { OriginalPostion = 1 },
+                new TestPosition { OriginalPostion = 0 }
+            };
+
+            // when
+            bool success = client.ReorderTests(testFile.Filename, reorder);
+
+            // then
+            Assert.True(success);
+
+            var updatedTestFile = client.GetTestFile(testFile.Filename);
+            Assert.That(updatedTestFile.Tests.Count(), Is.EqualTo(2));
+            Assert.That(updatedTestFile.Variables.Count, Is.EqualTo(testFile.Variables.Count));
+
+            Assert.That(updatedTestFile.Tests.First().Description, Is.EqualTo(testFile.Tests.Skip(1).First().Description));
+            Assert.That(updatedTestFile.Tests.Skip(1).First().Description, Is.EqualTo(testFile.Tests.First().Description));
+        }
     }
 }

--- a/src/Syringe.Tests/Integration/Core/Tests/Repositories/Json/JsonExamples/full-test-file.json
+++ b/src/Syringe.Tests/Integration/Core/Tests/Repositories/Json/JsonExamples/full-test-file.json
@@ -53,5 +53,6 @@
         "Name": "Env2"
       }
     }
-  ]
+  ],
+  "EngineVersion": 3
 }

--- a/src/Syringe.Tests/Integration/Core/Tests/Repositories/Json/TestFileWriterTests.cs
+++ b/src/Syringe.Tests/Integration/Core/Tests/Repositories/Json/TestFileWriterTests.cs
@@ -23,6 +23,7 @@ namespace Syringe.Tests.Integration.Core.Tests.Repositories.Json
             var testFile = new TestFile
             {
                 Filename = "I SHOULD ALSO NOT EXIST",
+                EngineVersion = 3,
                 Variables = new List<Variable>
                 {
                     new Variable

--- a/src/Syringe.Tests/StubsMocks/TestFileWriterStub.cs
+++ b/src/Syringe.Tests/StubsMocks/TestFileWriterStub.cs
@@ -1,0 +1,17 @@
+﻿using Syringe.Core.Tests;
+using Syringe.Core.Tests.Repositories;
+
+namespace Syringe.Tests.StubsMocks
+{
+    public class TestFileWriterStub : ITestFileWriter
+    {
+        public string Write_Result { get; set; }
+        public TestFile Write_Value { get; private set; }
+
+        public string Write(TestFile testFile)
+        {
+            Write_Value = testFile;
+            return Write_Result;
+        }
+    }
+}

--- a/src/Syringe.Tests/Syringe.Tests.csproj
+++ b/src/Syringe.Tests/Syringe.Tests.csproj
@@ -243,6 +243,7 @@
     <Compile Include="StubsMocks\TestFileResultRepositoryFactoryMock.cs" />
     <Compile Include="StubsMocks\TestFileRunnerLogFactoryMock.cs" />
     <Compile Include="StubsMocks\TestFileRunnerLoggerMock.cs" />
+    <Compile Include="StubsMocks\TestFileWriterStub.cs" />
     <Compile Include="StubsMocks\VariableContainerStub.cs" />
     <Compile Include="StubsMocks\Web\TestControllerWrapper.cs" />
     <Compile Include="Unit\Client\RestSharpHelpers\RestSharpClientFactoryTests.cs" />

--- a/src/Syringe.Tests/Unit/Core/Tests/Repositories/TestRepositoryTests.cs
+++ b/src/Syringe.Tests/Unit/Core/Tests/Repositories/TestRepositoryTests.cs
@@ -41,6 +41,7 @@ namespace Syringe.Tests.Unit.Core.Tests.Repositories
             _fileHandler.Setup(x => x.WriteAllText(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
             _fileHandler.Setup(x => x.GetFileNames()).Returns(new List<string> { { "test" } });
             _testFileWriter.Setup(x => x.Write(It.IsAny<TestFile>())).Returns(jsonContent);
+            _configuration.Setup(x => x.EngineVersion).Returns(54);
         }
 
         [Test]

--- a/src/Syringe.Tests/Unit/Core/Tests/Repositories/TestRepositoryTests.cs
+++ b/src/Syringe.Tests/Unit/Core/Tests/Repositories/TestRepositoryTests.cs
@@ -168,12 +168,27 @@ namespace Syringe.Tests.Unit.Core.Tests.Repositories
             _testFileWriter.Verify(x => x.Write(It.IsAny<TestFile>()), Times.Once);
         }
 
-
         [Test]
-        public void UpdateTestFile_should_return_true_if_file_exists()
+        public void UpdateTestVariables_should_return_true_if_file_exists()
         {
             // given + when
             bool success = _testRepository.UpdateTestVariables(new TestFile { Filename = filename });
+
+            // then
+            Assert.IsTrue(success);
+            _fileHandler.Verify(x => x.GetFileFullPath(It.IsAny<string>()), Times.Once);
+            _fileHandler.Verify(x => x.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _fileHandler.Verify(x => x.ReadAllText(It.IsAny<string>()), Times.Once);
+
+            _testFileWriter.Verify(x => x.Write(It.IsAny<TestFile>()), Times.Once);
+            _testFileReader.Verify(x => x.Read(It.IsAny<TextReader>()), Times.Once);
+        }
+
+        [Test]
+        public void UpdateTests_should_return_true_if_file_exists()
+        {
+            // given + when
+            bool success = _testRepository.UpdateTests(new TestFile { Filename = filename });
 
             // then
             Assert.IsTrue(success);
@@ -221,21 +236,6 @@ namespace Syringe.Tests.Unit.Core.Tests.Repositories
             _fileHandler.Verify(x => x.GetFileFullPath(It.IsAny<string>()), Times.Once);
             _fileHandler.Verify(x => x.DeleteFile(It.IsAny<string>()), Times.Once);
             Assert.IsFalse(deleteFile);
-        }
-
-        [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public void Reorder_should_return_true_or_false_if_file_got_saved_after_the_tests_got_reordered(bool fileSaved)
-        {
-            // given + when
-            _fileHandler.Setup(x => x.WriteAllText(It.IsAny<string>(), It.IsAny<string>())).Returns(fileSaved);
-            var reorder = _testRepository.Reorder(It.IsAny<string>(), new List<TestPosition>());
-            // then
-            _fileHandler.Verify(x => x.GetFileFullPath(It.IsAny<string>()), Times.Once);
-            _fileHandler.Verify(x => x.ReadAllText(It.IsAny<string>()), Times.Once);
-            _fileHandler.Verify(x => x.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-            Assert.AreEqual(fileSaved, reorder);
         }
     }
 }

--- a/src/Syringe.Tests/Unit/Web/Controllers/JsonControllerTests.cs
+++ b/src/Syringe.Tests/Unit/Web/Controllers/JsonControllerTests.cs
@@ -40,17 +40,6 @@ namespace Syringe.Tests.Unit.Web.Controllers
             Assert.AreEqual("{ taskId = 10 }", actionResult.Data.ToString());
         }
 
-        //[Test]
-        //public void GetProgress_should_return_correct_json()
-        //{
-        //    // given + when
-        //    var actionResult = jsonController.GetProgress(It.IsAny<int>()) as ContentResult;
-
-        //    // then
-        //    _tasksClient.Verify(x => x.GetTask(It.IsAny<int>()), Times.Once);
-        //    Assert.AreEqual("{\"TaskId\":0,\"Filename\":null,\"Username\":null,\"Status\":null,\"IsComplete\":false,\"CurrentIndex\":0,\"TotalTests\":0,\"Results\":[],\"Errors\":null}", actionResult.Content);
-        //}
-
         [Test]
         public void GetTests_should_return_correct_json()
         {
@@ -59,7 +48,7 @@ namespace Syringe.Tests.Unit.Web.Controllers
 
             // then
             _testsClient.Verify(x => x.GetTestFile(It.IsAny<string>()), Times.Once);
-            Assert.AreEqual("{\"Tests\":[],\"Filename\":null,\"Variables\":[]}", actionResult.Content);
+            Assert.AreEqual("{\"Tests\":[],\"Filename\":null,\"Variables\":[],\"EngineVersion\":0}", actionResult.Content);
         }
     }
 }

--- a/src/Syringe.Tests/Unit/Web/Controllers/TestFileControllerTests.cs
+++ b/src/Syringe.Tests/Unit/Web/Controllers/TestFileControllerTests.cs
@@ -272,12 +272,13 @@ namespace Syringe.Tests.Unit.Web.Controllers
         public void ReorderTests_should_return_true_or_false_depending_on_reorder_success(bool testsReordered)
         {
             // given
-            _testServiceMock.Setup(x => x.Reorder(It.IsAny<string>(),It.IsAny<IEnumerable<TestPosition>>())).Returns(testsReordered);
+            _testServiceMock.Setup(x => x.ReorderTests(It.IsAny<string>(), It.IsAny<IEnumerable<TestPosition>>())).Returns(testsReordered);
+
             // when
             var jsonResult = _testFileController.ReorderTests(It.IsAny<string>(), It.IsAny<IEnumerable<TestPosition>>());
 
             // then
-            _testServiceMock.Verify(x => x.Reorder(It.IsAny<string>(), It.IsAny<IEnumerable<TestPosition>>()), Times.Once);
+            _testServiceMock.Verify(x => x.ReorderTests(It.IsAny<string>(), It.IsAny<IEnumerable<TestPosition>>()), Times.Once);
 
             Assert.That(jsonResult, Is.Not.Null);
             Assert.AreEqual(jsonResult.Data, testsReordered);

--- a/src/Syringe.Web/Controllers/TestFileController.cs
+++ b/src/Syringe.Web/Controllers/TestFileController.cs
@@ -194,7 +194,7 @@ namespace Syringe.Web.Controllers
         [HttpPost]
         public JsonResult ReorderTests(string filename, IEnumerable<TestPosition> tests)
         {
-            var testFileOrder = _testsClient.Reorder(filename, tests);
+            var testFileOrder = _testsClient.ReorderTests(filename, tests);
 
             return Json(testFileOrder);
         }

--- a/src/Syringe.Web/Views/TestFile/Update.cshtml
+++ b/src/Syringe.Web/Views/TestFile/Update.cshtml
@@ -31,7 +31,7 @@
             </div>
 
             <div class="pull-right">
-                <input type="submit" value="save" class="btn btn-primary" />
+                <input type="submit" value="Save" class="btn btn-primary" />
             </div>
         </form>
     </div>


### PR DESCRIPTION
This feature will stop editing of a file via Syringe if it is built with a newer version of Syringe.

We now store down `EngineVersion" and compare it to an internal value.