### PR TITLE
Enabling other content-type than x-www-form-urlencoded in post method

### DIFF
--- a/src/Syringe.Core/Http/HttpClient.cs
+++ b/src/Syringe.Core/Http/HttpClient.cs
@@ -65,28 +65,31 @@ namespace Syringe.Core.Http
 			_restClient.BaseUrl = uri;
 			_restClient.CookieContainer = _cookieContainer;
 
-			//
-			// Make the request adding the content-type, body and headers
-			//
-			Method method = GetMethodEnum(httpMethod);
-			var request = new RestRequest(method);
-			if (method == Method.POST)
-			{
-				const string contentType = "application/x-www-form-urlencoded";
+            //
+            // Make the request adding the content-type, body and headers
+            //
+            
+            Method method = GetMethodEnum(httpMethod);
+            
+            var request = new RestRequest(method);
+            var contentType = "application/x-www-form-urlencoded";
 
-				// From the RestSharp docs:
-				// "The name of the parameter will be used as the Content-Type header for the request."
-				request.AddParameter(contentType, postBody, ParameterType.RequestBody);
-			}
-
-			if (headers != null)
+            if (headers != null)
+            {
+                headers = headers.ToList();
+                foreach (var keyValuePair in headers)
+                {
+                    request.AddHeader(keyValuePair.Key, keyValuePair.Value);
+                    if (String.Compare(keyValuePair.Key, "content-type", true) == 0)
+                    {
+                        contentType = keyValuePair.Value;
+                    }
+                }
+            }
+            if (method == Method.POST)
 			{
-				headers = headers.ToList();
-				foreach (var keyValuePair in headers)
-				{
-					request.AddHeader(keyValuePair.Key, keyValuePair.Value);
-				}
-			}
+                request.AddParameter(contentType, postBody, ParameterType.RequestBody);
+            }        
 
 			return request;
 		}

--- a/src/Syringe.Tests/Unit/Core/Http/HttpClientTests.cs
+++ b/src/Syringe.Tests/Unit/Core/Http/HttpClientTests.cs
@@ -188,6 +188,31 @@ namespace Syringe.Tests.Unit.Core.Http
 			Assert.That(response.ResponseTime, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1)));
 		}
 
+		[Test]
+        public async Task should_post_request_use_content_type_from_header()
+        {
+            // given
+            var httpLogWriter = GetHttpLogWriter();
+            HttpClient httpClient = CreateClient(new RestResponse());
+
+            string method = "post";
+            string url = "http://www.example.com";
+            string postBody = "keywords=foo&location=london";            
+            var headers = new List<HeaderItem>()
+            {
+                new HeaderItem("content-type", "application/json"),
+            };
+            var restRequest = httpClient.CreateRestRequest(method, url, postBody, headers);
+
+            // when
+            await httpClient.ExecuteRequestAsync(restRequest, httpLogWriter);
+
+            // then
+            Parameter parameter = _restClientMock.RestRequest.Parameters.First();
+            Assert.AreEqual("content-type", parameter.Name);
+            Assert.AreEqual("application/json", parameter.Value);
+        }
+		
 		private HttpClient CreateClient(IRestResponse restResponse)
 		{
 			_restClientMock = new RestClientMock();


### PR DESCRIPTION
@yetanotherchris, @hemdagem Could you look at small fix which enables using content-types like json or html in POST requests.